### PR TITLE
fix(release testing/instance toggle) version external api and support ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Optional. Information regarding the devices used during the call.
 Optional. Details about the participant that started the meeting.
 
 ###### `release`
-Optional. Information regarding the `stage.8x8.vc` or `8x8.vc` release version. Expects the following format: `release-${number}`.
+Optional. Information regarding the `stage.8x8.vc` or `8x8.vc` release version.
 
 ###### `spinner`
 Optional. Custom loading view while the IFrame is loading.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -29,7 +29,7 @@
         },
         "..": {
             "name": "@jitsi/react-sdk",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "^7.15.8",

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -205,7 +205,11 @@ const App = () => {
             <JaaSMeeting
                 roomName = { generateRoomName() }
 
-                // release = 'release-3110' // Update this with the version of interest.
+                // Update this with the version of interest
+                // and avoid mixing up different domains and release versions
+                // on the same page at the same time, as only the first
+                // external api script will be loaded.
+                // release = '3446'
                 useStaging = { true }
                 getIFrameRef = { handleJaaSIFrameRef } />
             {renderButtons()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@jitsi/react-sdk",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@jitsi/react-sdk",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jitsi/react-sdk",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "React SDK for the Jitsi Meet IFrame",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/components/JitsiMeeting.tsx
+++ b/src/components/JitsiMeeting.tsx
@@ -1,4 +1,11 @@
-import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import {
+    ReactElement,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
+} from 'react';
 
 import { DEFAULT_DOMAIN } from '../constants';
 import { fetchExternalApi } from '../init';
@@ -36,16 +43,17 @@ const JitsiMeeting = ({
     onReadyToClose,
     getIFrameRef
 }: IJitsiMeetingProps): ReactElement => {
-    const [ componentId, setComponentId ] = useState<string>('');
     const [ loading, setLoading ] = useState(true);
     const [ apiLoaded, setApiLoaded ] = useState(false);
     const externalApi = useRef<JitsiMeetExternalApi>();
     const apiRef = useRef<IJitsiMeetExternalApi>();
     const meetingRef = useRef<HTMLDivElement>(null);
+    const componentId = useMemo(() =>
+        generateComponentId('jitsiMeeting')
+    , [ generateComponentId ]);
 
     useEffect(() => {
-        setComponentId(generateComponentId('jitsiMeeting'));
-        fetchExternalApi(domain)
+        fetchExternalApi(domain, release)
             .then((api: JitsiMeetExternalApi) => {
                 externalApi.current = api;
                 setApiLoaded(true);
@@ -62,7 +70,7 @@ const JitsiMeeting = ({
             invitees,
             devices,
             userInfo,
-            release,
+            ...release ? { release: `release-${release}` } : {},
             parentNode: meetingRef.current
         });
         setLoading(false);

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,16 +2,18 @@ import { DEFAULT_DOMAIN } from './constants';
 import { JitsiMeetExternalApi } from './types';
 
 const loadExternalApi = async (
-        domain: string
+        domain: string,
+        release?: string
 ): Promise<JitsiMeetExternalApi> => new Promise((resolve, reject) => {
     if (window.JitsiMeetExternalAPI) {
         return resolve(window.JitsiMeetExternalAPI);
     }
 
     const script: HTMLScriptElement = document.createElement('script');
+    const releaseParam: string = release ? `?release=release-${release}` : '';
 
     script.async = true;
-    script.src = `https://${domain}/external_api.js`;
+    script.src = `https://${domain}/external_api.js${releaseParam}`;
     script.onload = () => resolve(window.JitsiMeetExternalAPI);
     script.onerror = () => reject(new Error(`Script load error: ${script.src}`));
     document.head.appendChild(script as Node);
@@ -22,17 +24,24 @@ let scriptPromise: Promise<JitsiMeetExternalApi>;
 
 /**
  * Injects the external_api.js script for the corresponding domain in DOM
- * and resolves with either the `JitsiMeetExternalApi` class definition or an error
+ * and resolves with either the `JitsiMeetExternalApi` class definition or an error.
+ *
+ * Only the first script will be injected, therefore avoid using multiple instances
+ * with mixed domains and release version at the same time.
  *
  * @param {string} domain - The domain of the external API
- * @returns {Promise<JitsiMeetExternalApi>} - the JitsiMeetExternalAPI or an error
+ * @param {string} release - The Jitsi Meet release
+ * @returns {Promise<JitsiMeetExternalApi>} - The JitsiMeetExternalAPI or an error
  */
-export const fetchExternalApi = (domain: string = DEFAULT_DOMAIN): Promise<JitsiMeetExternalApi> => {
+export const fetchExternalApi = (
+        domain: string = DEFAULT_DOMAIN,
+        release?: string
+): Promise<JitsiMeetExternalApi> => {
     if (scriptPromise) {
         return scriptPromise;
     }
 
-    scriptPromise = loadExternalApi(domain);
+    scriptPromise = loadExternalApi(domain, release);
 
     return scriptPromise;
 };

--- a/src/types/IMeetingProps.ts
+++ b/src/types/IMeetingProps.ts
@@ -73,7 +73,6 @@ export default interface IMeetingProps {
 
     /**
      * The `stage.8x8.vc` or `8x8.vc` release version to test.
-     * Expects the following format: `release-${number}`.
      */
     release?: string;
 

--- a/src/types/JitsiMeetExternalApi.ts
+++ b/src/types/JitsiMeetExternalApi.ts
@@ -94,7 +94,7 @@ export type JitsiMeetExternalApi = {
 
             /**
              * The `stage.8x8.vc` or `8x8.vc` release version to test.
-             * Expects the following format: `release-${number}`.
+             * Expects the following format: `release-${string}`.
              */
             release?: string,
 


### PR DESCRIPTION
…tance toggle on react 18

A bit conflicted about the package version bump: I did change the expected format for the release prop (so it's no longer backwards compatible), but no one should use this field in production 🤔 

PS: sorry for fixing more than one issue in the same pr 🥲 