### PR TITLE
Fix prop name to be configOverwrite in example

### DIFF
--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -195,7 +195,7 @@ const App = () => {
             <JitsiMeeting
                 roomName = { generateRoomName() }
                 spinner = { renderSpinner }
-                config = {{
+                configOverwrite = {{
                     subject: 'lalalala',
                     hideConferenceSubject: false
                 }}


### PR DESCRIPTION
In `example/src/App.jsx`, for JitsiMeeting component, the prop name is currently `config` when it should be `configOverwrite`