### PR TITLE
fix: finish showing spinner in JitsiMeeting on iframe load event

### DIFF
--- a/src/components/JitsiMeeting.tsx
+++ b/src/components/JitsiMeeting.tsx
@@ -73,9 +73,9 @@ const JitsiMeeting = ({
             userInfo,
             release,
             lang,
-            parentNode: meetingRef.current
+            parentNode: meetingRef.current,
+            onload: () => setLoading(false)
         });
-        setLoading(false);
         if (apiRef.current) {
             typeof onApiReady === 'function' && onApiReady(apiRef.current);
             apiRef.current.on('readyToClose', () => {
@@ -104,23 +104,24 @@ const JitsiMeeting = ({
     ]);
 
     useEffect(() => {
-        if (apiLoaded && !apiRef.current) {
-            if (externalApi.current) {
-                loadIFrame(externalApi.current);
-            }
+        if (!apiLoaded || apiRef.current || !externalApi.current) {
+            return;
         }
+
+        loadIFrame(externalApi.current);
     }, [ apiLoaded, loadIFrame ]);
 
     const renderLoadingSpinner = useCallback(() => {
         if (!Spinner) {
             return null;
         }
-        if (!loading || apiRef.current) {
+
+        if (!loading) {
             return null;
         }
 
         return <Spinner />;
-    }, [ Spinner, apiRef.current ]);
+    }, [ Spinner, loading ]);
 
     return (
         <>


### PR DESCRIPTION
Added the `onload` event listener to [the jitsi iframe](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#creating-the-jitsi-meet-api-object) to ensure we can reliably detect when the iframe content has finished loading. This improves stability by making iframe initialization explicit instead of depending on implicit behavior that we finish loading when we just initialize `JitsiMeetExternalAPI`.

Resolves #40

